### PR TITLE
Refactor/#13: 크롤링 성능 최적화 및 사람인 면접 후기 추가

### DIFF
--- a/crawler/combined.py
+++ b/crawler/combined.py
@@ -1,0 +1,130 @@
+from typing import Dict, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    # main.py에서 import할 때
+    from crawler.job import crawl_interview_reviews as crawl_jobkorea, get_company_url
+    from crawler.saramin import crawl_saramin_reviews, get_saramin_url
+except ImportError:
+    # crawler 디렉토리에서 직접 실행할 때
+    from job import crawl_interview_reviews as crawl_jobkorea, get_company_url
+    from saramin import crawl_saramin_reviews, get_saramin_url
+
+
+def crawl_all_reviews(company_name: str) -> Dict:
+    """
+    잡코리아와 사람인에서 면접 후기를 동시에 크롤링하는 함수
+
+    Args:
+        company_name: 기업 이름 (영어 키: naver, kakao, line, coupang, baemin)
+
+    Returns:
+        dict: 통합 크롤링 결과
+            - company_name: 회사명
+            - reviews: 면접 후기 리스트 (잡코리아 먼저, 사람인 다음)
+            - total_reviews: 총 면접 후기 개수
+            - jobkorea_count: 잡코리아 후기 개수
+            - saramin_count: 사람인 후기 개수
+            - error: 에러 메시지 (있을 경우)
+    """
+
+    company_name_result = None
+    jobkorea_count = 0
+    saramin_count = 0
+    errors = []
+
+    # URL 확인
+    jobkorea_url = get_company_url(company_name)
+    saramin_url = get_saramin_url(company_name)
+
+    # 병렬 크롤링 실행
+    jobkorea_result = None
+    saramin_result = None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = {}
+
+        # 잡코리아 크롤링 시작
+        if jobkorea_url:
+            futures['jobkorea'] = executor.submit(crawl_jobkorea, jobkorea_url)
+        else:
+            errors.append("잡코리아: URL을 찾을 수 없습니다")
+
+        # 사람인 크롤링 시작
+        if saramin_url:
+            futures['saramin'] = executor.submit(crawl_saramin_reviews, saramin_url)
+        else:
+            errors.append("사람인: URL을 찾을 수 없습니다")
+
+        # 결과 수집 (순서 보장을 위해 직접 접근)
+        if 'jobkorea' in futures:
+            try:
+                jobkorea_result = futures['jobkorea'].result()
+            except Exception as e:
+                errors.append(f"잡코리아: {str(e)}")
+
+        if 'saramin' in futures:
+            try:
+                saramin_result = futures['saramin'].result()
+            except Exception as e:
+                errors.append(f"사람인: {str(e)}")
+
+    # 결과 병합 (순서 유지: 잡코리아 먼저, 사람인 다음)
+    all_reviews = []
+
+    # 1. 잡코리아 결과 추가
+    if jobkorea_result:
+        if "error" not in jobkorea_result:
+            all_reviews.extend(jobkorea_result.get("reviews", []))
+            jobkorea_count = jobkorea_result.get("total_reviews", 0)
+            if not company_name_result and jobkorea_result.get("company_name"):
+                company_name_result = jobkorea_result.get("company_name")
+        else:
+            errors.append(f"잡코리아: {jobkorea_result['error']}")
+
+    # 2. 사람인 결과 추가
+    if saramin_result:
+        if "error" not in saramin_result:
+            all_reviews.extend(saramin_result.get("reviews", []))
+            saramin_count = saramin_result.get("total_reviews", 0)
+            if not company_name_result and saramin_result.get("company_name"):
+                company_name_result = saramin_result.get("company_name")
+        else:
+            errors.append(f"사람인: {saramin_result['error']}")
+
+    # 결과 반환
+    result = {
+        "company_name": company_name_result or "정보 없음",
+        "reviews": all_reviews,
+        "total_reviews": len(all_reviews),
+        "jobkorea_count": jobkorea_count,
+        "saramin_count": saramin_count
+    }
+
+    if errors:
+        result["errors"] = errors
+
+    return result
+
+
+def get_combined_url(company_name: str) -> Optional[Dict[str, str]]:
+    """
+    기업 이름으로 잡코리아와 사람인 URL을 찾는 함수
+
+    Args:
+        company_name: 기업 이름
+
+    Returns:
+        dict: URL 정보 또는 None
+            - jobkorea: 잡코리아 URL
+            - saramin: 사람인 URL
+    """
+    jobkorea_url = get_company_url(company_name)
+    saramin_url = get_saramin_url(company_name)
+
+    if jobkorea_url or saramin_url:
+        return {
+            "jobkorea": jobkorea_url,
+            "saramin": saramin_url
+        }
+    return None

--- a/crawler/job.py
+++ b/crawler/job.py
@@ -1,6 +1,5 @@
 import requests
 from bs4 import BeautifulSoup
-import time
 from typing import Dict, Optional
 
 def crawl_interview_reviews(company_url: str) -> Dict:
@@ -34,9 +33,6 @@ def crawl_interview_reviews(company_url: str) -> Dict:
             "company_name": None,
             "reviews": []
         }
-
-    # 서버 과부하 방지를 위한 지연
-    time.sleep(3)
 
     # HTML 파싱
     soup = BeautifulSoup(html_content, 'html.parser')
@@ -131,17 +127,3 @@ def get_company_url(company_name: str) -> Optional[str]:
         str: URL 템플릿 또는 None
     """
     return COMPANY_URL_MAP.get(company_name)
-
-
-# 직접 실행 시 테스트
-if __name__ == "__main__":
-    result = crawl_interview_reviews("924", 1)
-    print(f"회사명: {result['company_name']}")
-    print(f"총 {result['total_reviews']}개의 면접 후기")
-
-    for i, review in enumerate(result['reviews'][:2], 1):
-        print(f"\n=== 면접 후기 #{i} ===")
-        for q in review['questions'][:3]:
-            print(f"[{q['question']}]")
-            if 'answer' in q:
-                print(f"  > {q['answer'][:50]}...")

--- a/crawler/saramin.py
+++ b/crawler/saramin.py
@@ -1,0 +1,139 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import Dict, Optional
+
+def crawl_saramin_reviews(company_url: str) -> Dict:
+    """
+    사람인에서 면접 후기를 크롤링하는 함수
+
+    Args:
+        company_url: 회사별 URL
+
+    Returns:
+        dict: 크롤링 결과
+            - company_name: 회사명
+            - reviews: 면접 후기 리스트
+            - total_reviews: 총 면접 후기 개수
+            - error: 에러 메시지 (있을 경우)
+    """
+
+    # URL 사용
+    URL = company_url
+
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        response = requests.get(URL, headers=headers)
+        response.raise_for_status()
+        html_content = response.text
+    except requests.exceptions.RequestException as e:
+        return {
+            "error": f"웹사이트 요청 중 오류 발생: {str(e)}",
+            "company_name": None,
+            "reviews": []
+        }
+
+    # HTML 파싱
+    soup = BeautifulSoup(html_content, 'html.parser')
+
+    # 회사 이름 추출
+    company_name_tag = soup.select_one('.hd strong')
+    company_name = company_name_tag.text.strip() if company_name_tag else "정보 없음"
+
+    # 면접 후기 리스트 추출
+    reviews = []
+    review_boxes = soup.select('.box_review')
+
+    for box in review_boxes:
+        review_data = {"questions": []}
+
+        # 면접 정보 (면접 유형, 인원, 진행 방식 등)
+        info_views = box.select('.info_view')
+        for info in info_views:
+            title = info.select_one('.tit_view')
+            list_items = info.select('.list_item li')
+
+            if title:
+                key = title.get_text(strip=True)
+
+                # "면접 질문"은 나중에 qna_pairs로 처리하므로 제외
+                if key == "면접 질문":
+                    continue
+
+                if list_items:
+                    values = [li.get_text(strip=True) for li in list_items]
+                    value_str = ', '.join(values)
+                else:
+                    value_str = info.get_text(strip=True).replace(key, '').strip()
+
+                if value_str:
+                    review_data["questions"].append({
+                        "question": key,
+                        "answer": value_str
+                    })
+
+        # 질문 리스트 추출 (면접 질문)
+        question_list = box.select('.list_question')
+        if question_list:
+            questions_in_list = question_list[0].select('li')
+            qna_pairs = []
+            for li in questions_in_list:
+                question_text = li.get_text(strip=True)
+                if question_text:
+                    qna_pairs.append({
+                        "question": question_text,
+                        "answer": ""
+                    })
+
+            # 면접 질문이 있으면 qna_pairs 형식으로 추가
+            if qna_pairs:
+                review_data["questions"].append({
+                    "question": "면접 질문",
+                    "qna_pairs": qna_pairs
+                })
+
+        # 평가 정보 (전반적 평가, 난이도, 결과)
+        review_dls = box.select('.review')
+        for dl in review_dls:
+            dt = dl.select_one('dt')
+            dd = dl.select_one('dd')
+            if dt and dd:
+                key = dt.get_text(strip=True)
+                value = dd.get_text(strip=True)
+                review_data["questions"].append({
+                    "question": key,
+                    "answer": value
+                })
+
+        if review_data["questions"]:
+            reviews.append(review_data)
+
+    return {
+        "company_name": company_name,
+        "reviews": reviews,
+        "total_reviews": len(reviews)
+    }
+
+
+# 기업 이름 -> URL 매핑 (영어 키 사용)
+SARAMIN_URL_MAP = {
+    "naver": "https://www.saramin.co.kr/zf_user/interview-review?my=0&page=1&csn=&group_cd=&orderby=registration&career_cd=&job_category=2&company_nm=%EB%84%A4%EC%9D%B4%EB%B2%84",
+    "kakao": "https://www.saramin.co.kr/zf_user/interview-review?my=0&page=1&csn=&group_cd=&orderby=registration&career_cd=&job_category=2&company_nm=%EC%B9%B4%EC%B9%B4%EC%98%A4",
+    "line": "https://www.saramin.co.kr/zf_user/interview-review?my=0&page=1&csn=&group_cd=&orderby=registration&career_cd=&job_category=&company_nm=%EB%9D%BC%EC%9D%B8%ED%94%8C%EB%9F%AC%EC%8A%A4",
+    "coupang": "https://www.saramin.co.kr/zf_user/interview-review?my=0&page=1&csn=&group_cd=&orderby=registration&career_cd=&job_category=2&company_nm=%EC%BF%A0%ED%8C%A1",
+    "baemin": "https://www.saramin.co.kr/zf_user/interview-review?my=0&page=1&csn=&group_cd=&orderby=registration&career_cd=&job_category=&company_nm=%EC%9A%B0%EC%95%84%ED%95%9C%ED%98%95%EC%A0%9C%EB%93%A4"
+}
+
+
+def get_saramin_url(company_name: str) -> Optional[str]:
+    """
+    기업 이름으로 URL을 찾는 함수
+
+    Args:
+        company_name: 기업 이름
+
+    Returns:
+        str: URL 또는 None
+    """
+    return SARAMIN_URL_MAP.get(company_name)


### PR DESCRIPTION
<!-- PR 제목은 최종 커밋 메시지로 사용됩니다 -->
<!-- 형식: [타입]: [간결한 변경 요약] -->
<!-- 예: feat: 로그인 기능 구현 -->

## 요약
<!--
관련 이슈번호 작성
- 예) Closes #12
-->
> refactor #13

## 변경 내용
<!--
이 PR에서 수행한 주요 작업 내용을 작성해주세요.
-->

- sleep 제거를 통한 로딩 시간 감축
- 동일 기업에 대한 면접 후기 추가 (사람인)

## 체크리스트
<!-- 완료된 항목에 [x] 표시 -->
- [x] main이 아닌 develop 브런치로 설정했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다. (`feat`, `fix`, `refactor`, 등)
- [x] 코드 실행 및 테스트가 정상 동작함을 확인했습니다.
- [x] 변경된 코드에 대한 주석 또는 문서가 적절히 추가되었습니다.
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 풀 리퀘스트 제목에 컨벤션을 적용했습니다. 
- [x] Assignees에 나를 할당했습니다. 
- [x] 리뷰어를 등록했습니다.


## 스크리샷 / 테스트 결과
<!--
실행 스크린샷, 콘솔 출력, 테스트 결과 등
-->
네이버
<img width="1393" height="483" alt="네이버" src="https://github.com/user-attachments/assets/990711d0-32cb-4bd1-88bb-bd9c32c99e28" />
카카오
<img width="1398" height="484" alt="카카오" src="https://github.com/user-attachments/assets/7e995a02-0675-4bec-9656-9a3599107136" />
라인
<img width="1394" height="483" alt="라인플러스" src="https://github.com/user-attachments/assets/1f0f5205-118c-4620-b7ca-229d063e3862" />
쿠팡
<img width="1390" height="487" alt="쿠팡" src="https://github.com/user-attachments/assets/41d0bc96-879e-48e1-b482-3dae2621f853" />
배달의민족
<img width="1390" height="483" alt="배민" src="https://github.com/user-attachments/assets/b097fe29-7035-4cbd-a468-19dc0e45b728" />

## 참고 사항
<!--
리뷰 전에 꼭 알아야 할 내용이나 실행 시 주의할 점을 작성해주세요.
- 주의 사항이 없으면 "_No specific notes_" 라고 작성
-->
Returns: dict: 통합 크롤링 결과 - company_name: 회사명 - reviews: 면접 후기 리스트 (잡코리아 먼저, 사람인 다음) - total_reviews: 총 면접 후기 개수 - jobkorea_count: 잡코리아 후기 개수 - saramin_count: 사람인 후기 개수

네이버 8 -> 10
카카오 5 -> 8
라인 2 -> 5
쿠팡 7 -> 10
배달의민족 7 -> 17
각각 다음과 같이 증가

기존 양식을 최대한 유지, 기존 잡코리아 이후에 사람인 후기가 나오도록 조정
잡플래닛도 고려하였으나, 비로그인 상태에서의 접근성 문제가 있음